### PR TITLE
build packages in temporary directories

### DIFF
--- a/travis-ci/run-standard-tests.sh
+++ b/travis-ci/run-standard-tests.sh
@@ -16,7 +16,9 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     #   have to do this the hard way.
     go list -f '{{if (len .GoFiles)}}{{.ImportPath}}{{end}}' ./... | grep -v /vendor | \
         while read pkg; do
-            display_and_run go build "$pkg"
+            (
+                cd "$(mktemp -d)" && display_and_run go build "$pkg"
+            )
         done
 
     # Run tests with coverage report in each packages that has tests


### PR DESCRIPTION
If we build them all from the project root, the results will all go in the project root (which is a bit of a problem if the built binary has the same name as the package's directory).

We could just CD into the package's directory but it's safer to just build all this stuff in a temporary directory.

Note: I haven't tested this fix.