### PR TITLE
Modify Environment on TravisCI

### DIFF
--- a/travis-ci/run-standard-tests.sh
+++ b/travis-ci/run-standard-tests.sh
@@ -25,6 +25,25 @@ echo
 display_and_run $GOVETCMD ./...
 echo
 
+# Environment
+echo "*** Setting up test environment"
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    if [[ "$TRAVIS_SUDO" == true ]]; then
+        # Ensure that IPv6 is enabled.
+        # While this is unsupported by TravisCI, it still works for localhost.
+        sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
+        sudo sysctl -w net.ipv6.conf.default.disable_ipv6=0
+        sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+    fi
+else
+    if [[ "$TRAVIS_SUDO" == true ]]; then
+        # OSX has a default file limit of 256, for some tests we need a
+        # maximum of 8192.
+        sudo launchctl limit maxfiles 8192 8192
+        ulimit -n 8192
+    fi
+fi
+
 # Test
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     # Make sure everything can compile since some package may not have tests


### PR DESCRIPTION
This adds a section to run-standard-tests.sh to configure various
environment settings on TravisCI hosts. Currently we'll do the following:

1) On Linux hosts re-enable IPv6 support.
2) On OSX hosts increase the global maximum open file descriptor limit to 8192.

This is the successor to https://github.com/libp2p/go-reuseport/pull/35. I [tested the script](https://travis-ci.org/Coderlane/go-reuseport/builds/328503024) and [another modification](https://github.com/libp2p/go-reuseport/commit/b82cb3a4b0ff85d7a85632c45b020f32a8a3565b) on TravisCI and it seems to fix the issues go-reuseport was having on OSX.