### PR TITLE
add -o pipefail to run-standard-tests.sh

### DIFF
--- a/travis-ci/run-standard-tests.sh
+++ b/travis-ci/run-standard-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 display_and_run() {
     echo "***" "$@"


### PR DESCRIPTION
This build succeeded when it shouldn't have: https://travis-ci.org/libp2p/go-libp2p-webrtc-direct/builds/516417761