### PR TITLE
fix checking that plugins are buildable

### DIFF
--- a/travis-ci/run-standard-tests.sh
+++ b/travis-ci/run-standard-tests.sh
@@ -69,7 +69,12 @@ build_all() {
     #   have to do this the hard way.
     list_buildable | while read -r pkg dir; do
         echo '*** go build' "$pkg"
-        ( cd "$dir"; go build -o /dev/null "$pkg")
+        buildmode=archive
+        if [[ "$(go list -f '{{.Name}}')" == "main" ]]; then
+            # plugin works even when a "main" function is missing.
+            buildmode=plugin
+        fi
+        ( cd "$dir"; go build -buildmode=$buildmode -o /dev/null "$pkg")
     done
 }
 


### PR DESCRIPTION
Plugins don't have a main function and the "plugin" build mode also works for normal binaries _with_ a main function.